### PR TITLE
Replace Protagonist with Drafter.js

### DIFF
--- a/lib/blueprint-parser.js
+++ b/lib/blueprint-parser.js
@@ -1,7 +1,7 @@
 var async = require('async');
 var glob = require('glob');
 var fs = require('fs');
-var protagonist = require('protagonist');
+var drafter = require('drafter.js');
 var validator = require('./validator');
 var resultHandler = require('./result-handler');
 
@@ -24,7 +24,7 @@ var getExamples  = function (ast, callback) {
 function parseBlueprint(file, cb) {
     var data = fs.readFileSync(file, {encoding: 'utf8'});
     var options = {type: 'ast'};
-    protagonist.parse(data, options, function (error, result) {
+    drafter.parse(data, options, function (error, result) {
         if (error) {
             return cb(error, null, data);
         }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "dependencies": {
     "async": "^1.4.2",
     "colors": "^1.1.2",
+    "drafter.js": "^2.2.0",
     "glob": "^5.0.14",
     "lodash": "^3.10.1",
-    "protagonist": "^1.2.2",
     "tv4": "^1.2.3"
   }
 }


### PR DESCRIPTION
No C compilation required with Drafter.js :+1: 

Need this to then update the `grunt-blueprint-validator` and then to update `drakov` :+1: 