### PR TITLE
Adding a `bin` entry into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "url": "https://github.com/Aconex/api-blueprint-validator-module/blob/master/LICENSE-MIT"
     }
   ],
+  "bin": "./bin/validator",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
This just adds a `bin` entry into `package.json` so when you install the package, you can then do `./node_modules/.bin/api-blueprint-validator-module` to run the program.